### PR TITLE
Add short alias for color names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,30 @@ view.alpha = 30% // 0.3
 ```
 
 
+Short Color Name Alias
+----------------------
+
+With SwiftyColor, you can use short alias for default color names.
+
+| Color Name | Short | Even(?) Shorter |
+|---|---|---|
+| `UIColor.blackColor` | `UIColor.black` | `Color.black` |
+| `UIColor.darkGrayColor` | `UIColor.darkGray` | `Color.darkGray` |
+| `UIColor.lightGrayColor` | `UIColor.lightGray` | `Color.lightGray` |
+| `UIColor.whiteColor` | `UIColor.white` | `Color.white` |
+| `UIColor.grayColor` | `UIColor.gray` | `Color.gray` |
+| `UIColor.redColor` | `UIColor.red` | `Color.red` |
+| `UIColor.greenColor` | `UIColor.green` | `Color.green` |
+| `UIColor.blueColor` | `UIColor.blue` | `Color.blue` |
+| `UIColor.cyanColor` | `UIColor.cyan` | `Color.cyan` |
+| `UIColor.yellowColor` | `UIColor.yellow` | `Color.yellow` |
+| `UIColor.magentaColor` | `UIColor.magenta` | `Color.magenta` |
+| `UIColor.orangeColor` | `UIColor.orange` | `Color.orange` |
+| `UIColor.purpleColor` | `UIColor.purple` | `Color.purple` |
+| `UIColor.brownColor` | `UIColor.brown` | `Color.brown` |
+| `UIColor.clearColor` | `UIColor.clear` | `Color.clear` |
+
+
 License
 -------
 

--- a/SwiftyColor/SwiftyColor.swift
+++ b/SwiftyColor/SwiftyColor.swift
@@ -72,3 +72,23 @@ public func ~(color: Color, alpha: Float) -> Color {
 public func ~(color: Color, alpha: CGFloat) -> Color {
     return color.colorWithAlphaComponent(alpha)
 }
+
+
+/// short alias for color names
+public extension Color {
+    public class var black: Color { return self.blackColor() }
+    public class var darkGray: Color { return self.darkGrayColor() }
+    public class var lightGray: Color { return self.lightGrayColor() }
+    public class var white: Color { return self.whiteColor() }
+    public class var gray: Color { return self.grayColor() }
+    public class var red: Color { return self.redColor() }
+    public class var green: Color { return self.greenColor() }
+    public class var blue: Color { return self.blueColor() }
+    public class var cyan: Color { return self.cyanColor() }
+    public class var yellow: Color { return self.yellowColor() }
+    public class var magenta: Color { return self.magentaColor() }
+    public class var orange: Color { return self.orangeColor() }
+    public class var purple: Color { return self.purpleColor() }
+    public class var brown: Color { return self.brownColor() }
+    public class var clear: Color { return self.clearColor() }
+}


### PR DESCRIPTION
@rinatkhanov suggested in #4. (Thanks!)

`UIColor.blackColor` -> `UIColor.black`
`UIColor.darkGrayColor` -> `UIColor.darkGray`
`UIColor.lightGrayColor` -> `UIColor.lightGray`
`UIColor.whiteColor` -> `UIColor.white`
`UIColor.grayColor` -> `UIColor.gray`
`UIColor.redColor` -> `UIColor.red`
`UIColor.greenColor` -> `UIColor.green`
`UIColor.blueColor` -> `UIColor.blue`
`UIColor.cyanColor` -> `UIColor.cyan`
`UIColor.yellowColor` -> `UIColor.yellow`
`UIColor.magentaColor` -> `UIColor.magenta`
`UIColor.orangeColor` -> `UIColor.orange`
`UIColor.purpleColor` -> `UIColor.purple`
`UIColor.brownColor` -> `UIColor.brown`
`UIColor.clearColor` -> `UIColor.clear`

Or even(?) shorter: `UIColor.red` -> `Color.red`